### PR TITLE
feat: create CSS styling with retro arcade aesthetic

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,121 @@
+/* === Reset and Base Styles === */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Courier New', monospace;
+    background-color: #1a1a1a;
+    color: #ffffff;
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+/* === Game Container === */
+#game-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background-color: #000000;
+    border: 4px solid #ff0000;
+    border-radius: 8px;
+    box-shadow: 0 0 20px rgba(255, 0, 0, 0.5),
+                0 0 40px rgba(255, 0, 0, 0.3),
+                inset 0 0 10px rgba(0, 0, 0, 0.8);
+}
+
+/* === Canvas Styling === */
+#gameCanvas {
+    display: block;
+    background-color: #000080;
+    border: 2px solid #ffffff;
+    /* Pixel-perfect rendering */
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -webkit-crisp-edges;
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+    /* Disable smoothing */
+    -ms-interpolation-mode: nearest-neighbor;
+}
+
+/* === Responsive Design === */
+@media screen and (max-width: 1400px) {
+    #gameCanvas {
+        width: 100%;
+        height: auto;
+        max-width: 1280px;
+    }
+
+    #game-container {
+        padding: 15px;
+        max-width: 95vw;
+    }
+}
+
+@media screen and (max-width: 768px) {
+    #game-container {
+        padding: 10px;
+        border-width: 2px;
+    }
+
+    body {
+        padding: 10px;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    #game-container {
+        padding: 5px;
+        border-radius: 4px;
+    }
+}
+
+/* === Arcade Aesthetic === */
+#game-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: repeating-linear-gradient(
+        0deg,
+        rgba(0, 0, 0, 0.15),
+        rgba(0, 0, 0, 0.15) 1px,
+        transparent 1px,
+        transparent 2px
+    );
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* === Loading State === */
+#gameCanvas.loading {
+    opacity: 0.7;
+    filter: blur(2px);
+}
+
+/* === Retro Glow Effect === */
+@keyframes glow {
+    0%, 100% {
+        box-shadow: 0 0 20px rgba(255, 0, 0, 0.5),
+                    0 0 40px rgba(255, 0, 0, 0.3),
+                    inset 0 0 10px rgba(0, 0, 0, 0.8);
+    }
+    50% {
+        box-shadow: 0 0 30px rgba(255, 0, 0, 0.7),
+                    0 0 60px rgba(255, 0, 0, 0.5),
+                    inset 0 0 10px rgba(0, 0, 0, 0.8);
+    }
+}
+
+#game-container {
+    animation: glow 3s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
Implements issue #2 - Creates CSS styling with retro arcade aesthetic for the Donkey Kong game.

## Changes
- Created `styles.css` with comprehensive styling
- **Layout**: Canvas centered using flexbox
- **Theme**: Dark background with retro arcade feel
  - Body: #1a1a1a
  - Container: #000000 with red glowing border
  - Canvas: #000080 (classic arcade blue)
- **Retro Effects**:
  - Pixel-perfect rendering (image-rendering: pixelated)
  - Disabled canvas smoothing for crisp pixel art
  - Scanline overlay effect for CRT monitor aesthetic
  - Animated glowing red border
- **Typography**: Courier New monospace for retro feel
- **Responsive Design**: Media queries for different screen sizes
  - Desktop (1400px+): Full 1280x720 canvas
  - Tablet (768px-1400px): Scaled canvas
  - Mobile (480px-768px): Compact layout
  - Small mobile (<480px): Minimal padding

## Acceptance Criteria Met
- ✅ styles.css file created
- ✅ Canvas centered on page (flexbox)
- ✅ Retro/arcade styling applied
- ✅ Game container styling
- ✅ Responsive design for different screen sizes
- ✅ Pixel-perfect rendering (image-rendering: pixelated)
- ✅ No canvas smoothing

Closes #2