### PR TITLE
fix: add cache bust parameter to hammer sprite

### DIFF
--- a/js/entities/Hammer.js
+++ b/js/entities/Hammer.js
@@ -32,7 +32,7 @@ class Hammer {
         // Sprite loading
         // Custom hammer sprite (retro arcade style)
         this.spriteSheet = new Image();
-        this.spriteSheet.src = 'assets/sprites/hammer.png';
+        this.spriteSheet.src = 'assets/sprites/hammer.png?v=2'; // Cache bust
         this.spriteSheetLoaded = false;
         this.spriteSheet.onload = () => {
             this.spriteSheetLoaded = true;


### PR DESCRIPTION
Force browser to reload hammer.png by adding version query parameter (?v=2).

This fixes the browser cache issue where the old star sprite was still being displayed.