### PR TITLE
chore: add game.config.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ out/
 .env.test.local
 .env.production.local
 
+# User Configuration
+game.config.json
+
 # Logs
 logs/
 *.log


### PR DESCRIPTION
Adds game.config.json to .gitignore to prevent user-specific configuration files from being tracked in version control.

## Changes
- Added new "User Configuration" section to .gitignore
- Added game.config.json to the ignore list

## Rationale
- game.config.json appears to be a user-specific configuration file
- Should not be tracked in version control to avoid conflicts between different users/environments
- Follows standard .gitignore patterns for config files